### PR TITLE
fix: wrong binary name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
 builds:
-  - binary: hclwrite
+  - binary: hclfmt
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
goreleaser config had `hclwrite` binary name instead of `hclfmt`
